### PR TITLE
fixes: check if raw_response variable exists

### DIFF
--- a/src/httpapiclient/mixins.py
+++ b/src/httpapiclient/mixins.py
@@ -13,7 +13,7 @@ class JsonResponseMixin:
                     pass
             raise err
 
-        if request.raw_response:
+        if hasattr(request, 'raw_response') and request.raw_response:
             return response
         elif utils.get_content_type(response) == 'application/json':
             try:
@@ -30,7 +30,7 @@ class JsonSchemaResponseMixin(JsonResponseMixin):
         from jsonschema import Draft4Validator
 
         result = super().clean_response(response, request)
-        if request.raw_response:
+        if hasattr(request, 'raw_response') and request.raw_response:
             return result
 
         try:

--- a/src/httpapiclient/mixins.py
+++ b/src/httpapiclient/mixins.py
@@ -13,7 +13,7 @@ class JsonResponseMixin:
                     pass
             raise err
 
-        if hasattr(request, 'raw_response') and request.raw_response:
+        if request.raw_response:
             return response
         elif utils.get_content_type(response) == 'application/json':
             try:
@@ -30,7 +30,7 @@ class JsonSchemaResponseMixin(JsonResponseMixin):
         from jsonschema import Draft4Validator
 
         result = super().clean_response(response, request)
-        if hasattr(request, 'raw_response') and request.raw_response:
+        if request.raw_response:
             return result
 
         try:

--- a/src/httpapiclient/request.py
+++ b/src/httpapiclient/request.py
@@ -9,6 +9,7 @@ class ApiRequest(requests.Request):
             self._is_idempotent = kwargs.pop('is_idempotent')
         except KeyError:
             pass
+        self.raw_response = kwargs.pop('raw_response', False)
         super().__init__(*args, **kwargs)
 
     @property


### PR DESCRIPTION
Проблема: `JsonResponseMixin` и `JsonSchemaResponseMixin` используются для c`client-vk` но переменная `raw_response` задается только `SmpApiClient.Request`, который не наследуется в `VkClient`

Возможно есть лучший способ это исправить
И открыт вопрос по поводу тестов социальных клиентов